### PR TITLE
pass through didSelectItemAtIndexPath method with an adjusted index

### DIFF
--- a/Ouroboros/InfiniteCarousel.swift
+++ b/Ouroboros/InfiniteCarousel.swift
@@ -138,6 +138,11 @@ public class InfiniteCarousel: UICollectionView, UICollectionViewDataSource, UIC
         }
         return count + 2 * buffer
     }
+
+    public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
+        let adjustedPath = adjustedIndexPathForIndexPath(indexPath)
+        rootDelegate?.collectionView!(collectionView, didSelectItemAtIndexPath: adjustedPath)
+    }
     
     public func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
         let adjustedPath = adjustedIndexPathForIndexPath(indexPath)


### PR DESCRIPTION
We'd like to do something when an item in the carousel is selected, and it looks like message forwarding was removed at some point.
