### PR TITLE
precondition on adjustedIndexPath to prevent negative indices

### DIFF
--- a/Ouroboros/InfiniteCarousel.swift
+++ b/Ouroboros/InfiniteCarousel.swift
@@ -111,6 +111,7 @@ public class InfiniteCarousel: UICollectionView, UICollectionViewDataSource, UIC
     /// Returns the index path of the root data source item given an index path from this collection
     /// view, which naturally includes the buffer cells.
     public func adjustedIndexPathForIndexPath(indexPath: NSIndexPath) -> NSIndexPath {
+        precondition(count >= buffer, "Ouroboros requires at least twice the number of items per page to work properly. For best results: a number that is evenly divisible by the number of items per page.")
         let index = indexPath.item
         let wrapped = (index - buffer < 0) ? (count + (index - buffer)) : (index - buffer)
         let adjustedIndex = wrapped % count


### PR DESCRIPTION
* asserts that the number of items in ouroboros is greater than or equal to the buffer size
* should make the problem of too few items in the carousel more clear