### PR TITLE
Fix inconsistent indexPaths when calling reloadItemsAtIndexPaths

### DIFF
--- a/Ouroboros/InfiniteCarousel.swift
+++ b/Ouroboros/InfiniteCarousel.swift
@@ -206,6 +206,15 @@ public class InfiniteCarousel: UICollectionView, UICollectionViewDataSource, UIC
         currentlyFocusedItem = manualFocusCell!.item
         setNeedsFocusUpdate()
     }
+
+    public override func reloadItemsAtIndexPaths(indexPaths: [NSIndexPath]) {
+        guard count > 0 else {
+            super.reloadItemsAtIndexPaths(indexPaths)
+            return
+        }
+        let adjustedIntexPaths = carouselIndexPathsForOriginalIndexPaths(indexPaths)
+        super.reloadItemsAtIndexPaths(adjustedIntexPaths)
+    }
     
     func scrollToItem(item: Int, animated: Bool) {
         if let initialOffset = (self.collectionViewLayout as! Layout).offsetForItemAtIndex(item) {
@@ -260,7 +269,18 @@ public class InfiniteCarousel: UICollectionView, UICollectionViewDataSource, UIC
         self.setContentOffset(CGPointMake(currentOffset + jumpOffset, self.contentOffset.y),
             animated: false)
     }
-    
+
+    func carouselIndexPathsForOriginalIndexPaths(indexPaths: [NSIndexPath]) -> [NSIndexPath] {
+        return indexPaths.reduce([NSIndexPath]()) { (prev, index) -> [NSIndexPath] in
+            let adjustedIndex = NSIndexPath(forRow: index.row + buffer, inSection: index.section)
+            if index.row >= buffer && index.row < count - buffer {
+                return prev + [adjustedIndex]
+            }
+            let boundingIndexPath = NSIndexPath(forRow: (index.row + buffer + count) % (count * 2), inSection: index.section)
+            return prev + [adjustedIndex, boundingIndexPath]
+        }
+    }
+
     // MARK: - Layout
     
     class Layout: UICollectionViewFlowLayout {


### PR DESCRIPTION
Bug:
Calling reloadItemsAtIndexPaths method, the cellForItemAtIndexPath
method get a different indexPath
